### PR TITLE
feat: add favorite contacts feature

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -70,6 +70,7 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "transformIgnorePatterns": ["node_modules/(?!(uuid)/)"]
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { ContactsModule } from './contacts/contacts.module';
 
 @Module({
-  imports: [],
+  imports: [ContactsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/src/contacts/application/services/contacts.service.favorites.spec.ts
+++ b/backend/src/contacts/application/services/contacts.service.favorites.spec.ts
@@ -1,0 +1,126 @@
+import { NotFoundException } from '@nestjs/common';
+import { Contact } from '../../domain/entities/contact.entity';
+import { ContactRepository } from '../../domain/ports/contact.repository';
+import { ContactsService } from './contacts.service';
+
+class FakeContactRepository implements ContactRepository {
+  private contacts: Contact[] = [];
+
+  async save(contact: Contact): Promise<void> {
+    this.contacts.push(contact);
+  }
+
+  async findById(id: string): Promise<Contact | null> {
+    return this.contacts.find((c) => c.id === id) ?? null;
+  }
+
+  async findAll(): Promise<Contact[]> {
+    return [...this.contacts];
+  }
+
+  async update(contact: Contact): Promise<void> {
+    const index = this.contacts.findIndex((c) => c.id === contact.id);
+    if (index !== -1) this.contacts[index] = contact;
+  }
+
+  async delete(id: string): Promise<void> {
+    const index = this.contacts.findIndex((c) => c.id === id);
+    if (index !== -1) this.contacts.splice(index, 1);
+  }
+}
+
+describe('ContactsService — favorites', () => {
+  let service: ContactsService;
+  let repository: FakeContactRepository;
+
+  beforeEach(() => {
+    repository = new FakeContactRepository();
+    service = new ContactsService(repository);
+  });
+
+  it('should_set_isFavorite_true_when_contact_is_not_favorite', async () => {
+    // Arrange
+    const contact = new Contact('id-1', 'Alice', 'alice@example.com', '111', new Date(), false);
+    await repository.save(contact);
+
+    // Act
+    const result = await service.toggleFavorite('id-1');
+
+    // Assert
+    expect(result.isFavorite).toBe(true);
+  });
+
+  it('should_set_isFavorite_false_when_contact_is_already_favorite', async () => {
+    // Arrange
+    const contact = new Contact('id-2', 'Bob', 'bob@example.com', '222', new Date(), true);
+    await repository.save(contact);
+
+    // Act
+    const result = await service.toggleFavorite('id-2');
+
+    // Assert
+    expect(result.isFavorite).toBe(false);
+  });
+
+  it('should_return_updated_contact_with_all_fields_after_toggle', async () => {
+    // Arrange
+    const contact = new Contact('id-3', 'Carol', 'carol@example.com', '333', new Date(), false);
+    await repository.save(contact);
+
+    // Act
+    const result = await service.toggleFavorite('id-3');
+
+    // Assert
+    expect(result.id).toBe('id-3');
+    expect(result.name).toBe('Carol');
+    expect(result.isFavorite).toBe(true);
+  });
+
+  it('should_persist_favorite_change_when_toggle_is_called', async () => {
+    // Arrange
+    const contact = new Contact('id-4', 'Dave', 'dave@example.com', '444', new Date(), false);
+    await repository.save(contact);
+
+    // Act
+    await service.toggleFavorite('id-4');
+    const found = await service.findById('id-4');
+
+    // Assert
+    expect(found.isFavorite).toBe(true);
+  });
+
+  it('should_throw_NotFoundException_when_toggling_nonexistent_contact', async () => {
+    // Arrange — empty repository
+
+    // Act & Assert
+    await expect(service.toggleFavorite('ghost-id')).rejects.toThrow(NotFoundException);
+  });
+
+  it('should_return_favorites_first_when_findAll_called', async () => {
+    // Arrange
+    const regular = new Contact('a', 'Alice', 'alice@example.com', '111', new Date(), false);
+    const favorite = new Contact('b', 'Bob', 'bob@example.com', '222', new Date(), true);
+    await repository.save(regular);
+    await repository.save(favorite);
+
+    // Act
+    const result = await service.findAll();
+
+    // Assert
+    expect(result[0].isFavorite).toBe(true);
+    expect(result[1].isFavorite).toBe(false);
+  });
+
+  it('should_restore_isFavorite_false_when_toggled_twice', async () => {
+    // Arrange
+    const contact = new Contact('id-5', 'Eve', 'eve@example.com', '555', new Date(), false);
+    await repository.save(contact);
+
+    // Act
+    await service.toggleFavorite('id-5');
+    const result = await service.toggleFavorite('id-5');
+
+    // Assert
+    expect(result.isFavorite).toBe(false);
+  });
+});

--- a/backend/src/contacts/application/services/contacts.service.spec.ts
+++ b/backend/src/contacts/application/services/contacts.service.spec.ts
@@ -1,0 +1,152 @@
+import { NotFoundException } from '@nestjs/common';
+import { Contact } from '../../domain/entities/contact.entity';
+import { ContactRepository } from '../../domain/ports/contact.repository';
+import { ContactsService } from './contacts.service';
+
+class FakeContactRepository implements ContactRepository {
+  private contacts: Contact[] = [];
+
+  async save(contact: Contact): Promise<void> {
+    this.contacts.push(contact);
+  }
+
+  async findById(id: string): Promise<Contact | null> {
+    return this.contacts.find((c) => c.id === id) ?? null;
+  }
+
+  async findAll(): Promise<Contact[]> {
+    return [...this.contacts];
+  }
+
+  async update(contact: Contact): Promise<void> {
+    const index = this.contacts.findIndex((c) => c.id === contact.id);
+    if (index !== -1) this.contacts[index] = contact;
+  }
+
+  async delete(id: string): Promise<void> {
+    const index = this.contacts.findIndex((c) => c.id === id);
+    if (index !== -1) this.contacts.splice(index, 1);
+  }
+}
+
+describe('ContactsService', () => {
+  let service: ContactsService;
+  let repository: FakeContactRepository;
+
+  beforeEach(() => {
+    repository = new FakeContactRepository();
+    service = new ContactsService(repository);
+  });
+
+  it('should_return_created_contact_with_generated_id_when_input_is_valid', async () => {
+    // Arrange
+    const input = { name: 'Alice', email: 'alice@example.com', phone: '123456789' };
+
+    // Act
+    const result = await service.create(input);
+
+    // Assert
+    expect(result.id).toBeDefined();
+    expect(result.name).toBe('Alice');
+    expect(result.email).toBe('alice@example.com');
+    expect(result.phone).toBe('123456789');
+    expect(result.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('should_persist_contact_when_create_is_called', async () => {
+    // Arrange
+    const input = { name: 'Bob', email: 'bob@example.com', phone: '987654321' };
+
+    // Act
+    const created = await service.create(input);
+    const found = await service.findById(created.id);
+
+    // Assert
+    expect(found).toEqual(created);
+  });
+
+  it('should_return_contact_when_id_exists', async () => {
+    // Arrange
+    const contact = new Contact('abc-123', 'Carol', 'carol@example.com', '111222333', new Date());
+    await repository.save(contact);
+
+    // Act
+    const result = await service.findById('abc-123');
+
+    // Assert
+    expect(result).toEqual(contact);
+  });
+
+  it('should_throw_NotFoundException_when_id_not_found', async () => {
+    // Arrange — empty repository
+
+    // Act & Assert
+    await expect(service.findById('nonexistent')).rejects.toThrow(NotFoundException);
+  });
+
+  it('should_return_empty_array_when_no_contacts', async () => {
+    // Arrange — empty repository
+
+    // Act
+    const result = await service.findAll();
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it('should_return_all_contacts_when_multiple_exist', async () => {
+    // Arrange
+    const c1 = new Contact('1', 'Alice', 'alice@example.com', '111', new Date());
+    const c2 = new Contact('2', 'Bob', 'bob@example.com', '222', new Date());
+    await repository.save(c1);
+    await repository.save(c2);
+
+    // Act
+    const result = await service.findAll();
+
+    // Assert
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(expect.arrayContaining([c1, c2]));
+  });
+
+  it('should_update_only_provided_fields_when_partial_input', async () => {
+    // Arrange
+    const contact = new Contact('id-1', 'Alice', 'alice@example.com', '000', new Date());
+    await repository.save(contact);
+
+    // Act
+    const result = await service.update('id-1', { name: 'Alice Updated' });
+
+    // Assert
+    expect(result.name).toBe('Alice Updated');
+    expect(result.email).toBe('alice@example.com');
+    expect(result.phone).toBe('000');
+  });
+
+  it('should_throw_NotFoundException_when_updating_nonexistent_contact', async () => {
+    // Arrange — empty repository
+
+    // Act & Assert
+    await expect(service.update('ghost-id', { name: 'Ghost' })).rejects.toThrow(NotFoundException);
+  });
+
+  it('should_remove_contact_when_id_exists', async () => {
+    // Arrange
+    const contact = new Contact('del-1', 'Dave', 'dave@example.com', '333', new Date());
+    await repository.save(contact);
+
+    // Act
+    await service.remove('del-1');
+    const all = await service.findAll();
+
+    // Assert
+    expect(all).toHaveLength(0);
+  });
+
+  it('should_throw_NotFoundException_when_removing_nonexistent_contact', async () => {
+    // Arrange — empty repository
+
+    // Act & Assert
+    await expect(service.remove('ghost-id')).rejects.toThrow(NotFoundException);
+  });
+});

--- a/backend/src/contacts/application/services/contacts.service.ts
+++ b/backend/src/contacts/application/services/contacts.service.ts
@@ -1,0 +1,56 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import { Contact } from '../../domain/entities/contact.entity';
+import { CONTACT_REPOSITORY } from '../../domain/ports/contact.repository';
+import type { ContactRepository } from '../../domain/ports/contact.repository';
+import {
+  ContactsServicePort,
+  CreateContactInput,
+  UpdateContactInput,
+} from '../../domain/ports/contacts.service.port';
+
+@Injectable()
+export class ContactsService implements ContactsServicePort {
+  constructor(
+    @Inject(CONTACT_REPOSITORY)
+    private readonly contactRepository: ContactRepository,
+  ) {}
+
+  async create(input: CreateContactInput): Promise<Contact> {
+    const contact = new Contact(uuidv4(), input.name, input.email, input.phone, new Date());
+    await this.contactRepository.save(contact);
+    return contact;
+  }
+
+  async findById(id: string): Promise<Contact> {
+    const contact = await this.contactRepository.findById(id);
+    if (!contact) throw new NotFoundException(`Contact ${id} not found`);
+    return contact;
+  }
+
+  async findAll(): Promise<Contact[]> {
+    const all = await this.contactRepository.findAll();
+    return all.sort((a, b) => Number(b.isFavorite) - Number(a.isFavorite));
+  }
+
+  async toggleFavorite(id: string): Promise<Contact> {
+    const contact = await this.findById(id);
+    contact.isFavorite = !contact.isFavorite;
+    await this.contactRepository.update(contact);
+    return contact;
+  }
+
+  async update(id: string, input: UpdateContactInput): Promise<Contact> {
+    const contact = await this.findById(id);
+    if (input.name !== undefined) contact.name = input.name;
+    if (input.email !== undefined) contact.email = input.email;
+    if (input.phone !== undefined) contact.phone = input.phone;
+    await this.contactRepository.update(contact);
+    return contact;
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.findById(id);
+    await this.contactRepository.delete(id);
+  }
+}

--- a/backend/src/contacts/contacts.module.ts
+++ b/backend/src/contacts/contacts.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { ContactsService } from './application/services/contacts.service';
+import { CONTACT_REPOSITORY } from './domain/ports/contact.repository';
+import { CONTACTS_SERVICE } from './domain/ports/contacts.service.port';
+import { InMemoryContactRepository } from './infrastructure/adapters/in-memory-contact.repository';
+import { ContactsController } from './infrastructure/controllers/contacts.controller';
+
+@Module({
+  controllers: [ContactsController],
+  providers: [
+    {
+      provide: CONTACT_REPOSITORY,
+      useClass: InMemoryContactRepository,
+    },
+    {
+      provide: CONTACTS_SERVICE,
+      useClass: ContactsService,
+    },
+  ],
+})
+export class ContactsModule {}

--- a/backend/src/contacts/domain/entities/contact.entity.ts
+++ b/backend/src/contacts/domain/entities/contact.entity.ts
@@ -1,0 +1,10 @@
+export class Contact {
+  constructor(
+    public readonly id: string,
+    public name: string,
+    public email: string,
+    public phone: string,
+    public readonly createdAt: Date,
+    public isFavorite: boolean = false,
+  ) {}
+}

--- a/backend/src/contacts/domain/ports/contact.repository.ts
+++ b/backend/src/contacts/domain/ports/contact.repository.ts
@@ -1,0 +1,11 @@
+import { Contact } from '../entities/contact.entity';
+
+export const CONTACT_REPOSITORY = 'CONTACT_REPOSITORY';
+
+export interface ContactRepository {
+  save(contact: Contact): Promise<void>;
+  findById(id: string): Promise<Contact | null>;
+  findAll(): Promise<Contact[]>;
+  update(contact: Contact): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/backend/src/contacts/domain/ports/contacts.service.port.ts
+++ b/backend/src/contacts/domain/ports/contacts.service.port.ts
@@ -1,0 +1,24 @@
+import { Contact } from '../entities/contact.entity';
+
+export const CONTACTS_SERVICE = 'CONTACTS_SERVICE';
+
+export interface CreateContactInput {
+  name: string;
+  email: string;
+  phone: string;
+}
+
+export interface UpdateContactInput {
+  name?: string;
+  email?: string;
+  phone?: string;
+}
+
+export interface ContactsServicePort {
+  create(input: CreateContactInput): Promise<Contact>;
+  findById(id: string): Promise<Contact>;
+  findAll(): Promise<Contact[]>;
+  update(id: string, input: UpdateContactInput): Promise<Contact>;
+  remove(id: string): Promise<void>;
+  toggleFavorite(id: string): Promise<Contact>;
+}

--- a/backend/src/contacts/infrastructure/adapters/in-memory-contact.repository.ts
+++ b/backend/src/contacts/infrastructure/adapters/in-memory-contact.repository.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { Contact } from '../../domain/entities/contact.entity';
+import { ContactRepository } from '../../domain/ports/contact.repository';
+
+@Injectable()
+export class InMemoryContactRepository implements ContactRepository {
+  private readonly contacts: Contact[] = [];
+
+  async save(contact: Contact): Promise<void> {
+    this.contacts.push(contact);
+  }
+
+  async findById(id: string): Promise<Contact | null> {
+    return this.contacts.find((c) => c.id === id) ?? null;
+  }
+
+  async findAll(): Promise<Contact[]> {
+    return [...this.contacts];
+  }
+
+  async update(contact: Contact): Promise<void> {
+    const index = this.contacts.findIndex((c) => c.id === contact.id);
+    if (index !== -1) this.contacts[index] = contact;
+  }
+
+  async delete(id: string): Promise<void> {
+    const index = this.contacts.findIndex((c) => c.id === id);
+    if (index !== -1) this.contacts.splice(index, 1);
+  }
+}

--- a/backend/src/contacts/infrastructure/controllers/contacts.controller.ts
+++ b/backend/src/contacts/infrastructure/controllers/contacts.controller.ts
@@ -1,0 +1,56 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Param,
+  Patch,
+  Post,
+  Put,
+} from '@nestjs/common';
+import { CONTACTS_SERVICE } from '../../domain/ports/contacts.service.port';
+import type { ContactsServicePort } from '../../domain/ports/contacts.service.port';
+import { CreateContactDto } from '../dtos/create-contact.dto';
+import { UpdateContactDto } from '../dtos/update-contact.dto';
+
+@Controller('contacts')
+export class ContactsController {
+  constructor(
+    @Inject(CONTACTS_SERVICE)
+    private readonly contactsService: ContactsServicePort,
+  ) {}
+
+  @Post()
+  create(@Body() dto: CreateContactDto) {
+    return this.contactsService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.contactsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.contactsService.findById(id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateContactDto) {
+    return this.contactsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(@Param('id') id: string) {
+    return this.contactsService.remove(id);
+  }
+
+  @Patch(':id/favorite')
+  toggleFavorite(@Param('id') id: string) {
+    return this.contactsService.toggleFavorite(id);
+  }
+}

--- a/backend/src/contacts/infrastructure/dtos/create-contact.dto.ts
+++ b/backend/src/contacts/infrastructure/dtos/create-contact.dto.ts
@@ -1,0 +1,14 @@
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateContactDto {
+  @IsNotEmpty()
+  @IsString()
+  name: string;
+
+  @IsEmail()
+  email: string;
+
+  @IsNotEmpty()
+  @IsString()
+  phone: string;
+}

--- a/backend/src/contacts/infrastructure/dtos/update-contact.dto.ts
+++ b/backend/src/contacts/infrastructure/dtos/update-contact.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateContactDto } from './create-contact.dto';
+
+export class UpdateContactDto extends PartialType(CreateContactDto) {}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,10 @@
 import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,31 +1,83 @@
-import { useState } from 'react';
-import reactLogo from './assets/react.svg';
-import viteLogo from '/vite.svg';
-import './App.css';
+import { useState, useEffect } from 'react';
+import ContactForm from './components/ContactForm';
+import ContactList from './components/ContactList';
 
-function App() {
-  const [count, setCount] = useState(0);
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">Click on the Vite and React logos to learn more</p>
-    </>
-  );
+interface Contact {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  createdAt: string;
+  isFavorite: boolean;
 }
 
-export default App;
+type LoadingState = 'loading' | 'error' | 'ready';
+
+export default function App() {
+  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [status, setStatus] = useState<LoadingState>('loading');
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadContacts = async () => {
+      try {
+        const response = await fetch('http://localhost:3000/contacts');
+        if (!response.ok) {
+          throw new Error(`Error ${response.status}: ${response.statusText}`);
+        }
+        const data: Contact[] = await response.json();
+        setContacts(data);
+        setStatus('ready');
+      } catch (err) {
+        setFetchError(err instanceof Error ? err.message : 'Error al cargar los contactos');
+        setStatus('error');
+      }
+    };
+
+    loadContacts();
+  }, []);
+
+  const sortByFavorite = (list: Contact[]) =>
+    [...list].sort((a, b) => Number(b.isFavorite) - Number(a.isFavorite));
+
+  const handleContactCreated = (contact: Contact) => {
+    setContacts((prev) => sortByFavorite([contact, ...prev]));
+  };
+
+  const handleToggleFavorite = async (id: string) => {
+    const response = await fetch(`http://localhost:3000/contacts/${id}/favorite`, {
+      method: 'PATCH',
+    });
+    if (!response.ok) return;
+    const updated: Contact = await response.json();
+    setContacts((prev) => sortByFavorite(prev.map((c) => (c.id === id ? updated : c))));
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <header className="bg-indigo-600 shadow">
+        <div className="max-w-2xl mx-auto px-4 py-5">
+          <h1 className="text-2xl font-bold text-white tracking-tight">ContactBook</h1>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 py-8 space-y-6">
+        <ContactForm onContactCreated={handleContactCreated} />
+
+        {status === 'loading' && (
+          <p className="text-center text-gray-400 text-sm py-8">Cargando...</p>
+        )}
+
+        {status === 'error' && (
+          <div className="bg-red-50 border border-red-300 text-red-700 rounded-lg px-4 py-3 text-sm">
+            {fetchError}
+          </div>
+        )}
+
+        {status === 'ready' && (
+          <ContactList contacts={contacts} onToggleFavorite={handleToggleFavorite} />
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/ContactForm.tsx
+++ b/frontend/src/components/ContactForm.tsx
@@ -1,0 +1,108 @@
+import { useState, type FormEvent } from 'react';
+
+interface Contact {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  createdAt: string;
+  isFavorite: boolean;
+}
+
+interface ContactFormProps {
+  onContactCreated: (contact: Contact) => void;
+}
+
+interface FormFields {
+  name: string;
+  email: string;
+  phone: string;
+}
+
+const INITIAL_FIELDS: FormFields = { name: '', email: '', phone: '' };
+
+export default function ContactForm({ onContactCreated }: ContactFormProps) {
+  const [fields, setFields] = useState<FormFields>(INITIAL_FIELDS);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFields((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('http://localhost:3000/contacts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(fields),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Error ${response.status}: ${response.statusText}`);
+      }
+
+      const contact: Contact = await response.json();
+      setFields(INITIAL_FIELDS);
+      onContactCreated(contact);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al guardar el contacto');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-white rounded-2xl shadow p-6 space-y-4">
+      <h2 className="text-xl font-semibold text-gray-700">Nuevo contacto</h2>
+
+      {error && (
+        <div className="bg-red-50 border border-red-300 text-red-700 rounded-lg px-4 py-3 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <input
+          type="text"
+          name="name"
+          value={fields.name}
+          onChange={handleChange}
+          placeholder="Nombre"
+          required
+          className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+        />
+        <input
+          type="email"
+          name="email"
+          value={fields.email}
+          onChange={handleChange}
+          placeholder="Correo electrónico"
+          required
+          className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+        />
+        <input
+          type="tel"
+          name="phone"
+          value={fields.phone}
+          onChange={handleChange}
+          placeholder="Teléfono"
+          required
+          className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-300 text-white font-semibold py-2 px-4 rounded-lg transition-colors"
+      >
+        {loading ? 'Guardando...' : 'Guardar contacto'}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/ContactList.tsx
+++ b/frontend/src/components/ContactList.tsx
@@ -1,0 +1,63 @@
+interface Contact {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  createdAt: string;
+  isFavorite: boolean;
+}
+
+interface ContactListProps {
+  contacts: Contact[];
+  onToggleFavorite: (id: string) => void;
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('es-ES', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function ContactCard({
+  contact,
+  onToggleFavorite,
+}: {
+  contact: Contact;
+  onToggleFavorite: (id: string) => void;
+}) {
+  return (
+    <div className="bg-white rounded-2xl shadow px-6 py-4 flex items-start gap-3">
+      <button
+        onClick={() => onToggleFavorite(contact.id)}
+        className="mt-1 text-xl leading-none focus:outline-none"
+        aria-label={contact.isFavorite ? 'Quitar de favoritos' : 'Marcar como favorito'}
+      >
+        {contact.isFavorite ? '★' : '☆'}
+      </button>
+      <div className="flex flex-col gap-1 flex-1">
+        <p className="text-lg font-semibold text-gray-800">{contact.name}</p>
+        <p className="text-sm text-gray-500">{contact.email}</p>
+        <p className="text-sm text-gray-500">{contact.phone}</p>
+        <p className="text-xs text-gray-400 mt-1">Creado el {formatDate(contact.createdAt)}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function ContactList({ contacts, onToggleFavorite }: ContactListProps) {
+  if (contacts.length === 0) {
+    return (
+      <div className="text-center text-gray-400 py-12 text-sm">No hay contactos aún</div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {contacts.map((contact) => (
+        <ContactCard key={contact.id} contact={contact} onToggleFavorite={onToggleFavorite} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #1

- Adds `isFavorite: boolean` field to `Contact` entity (default `false`)
- New endpoint `PATCH /contacts/:id/favorite` that toggles the field
- `findAll` now returns favorites sorted first (application layer, no infra changes)
- Frontend: star button (★/☆) in each contact card triggers the toggle and re-sorts the list locally
- BDD unit tests for `toggleFavorite` and favorites sorting (`contacts.service.favorites.spec.ts`)

## Criterios de aceptación

- [x] Campo `isFavorite` en el modelo
- [x] Endpoint `PATCH /contacts/:id/favorite` funcionando
- [x] Test unitario para el caso de toggle (7 tests BDD)
- [x] UI con estrella clickeable (★/☆)
- [x] Favoritos ordenados primero (backend + frontend)

## Test plan

- [ ] `cd backend && npm run test` → 18 tests, 3 suites, todos verdes
- [ ] `cd frontend && npm run build` → build limpio sin errores TypeScript
- [ ] Levantar backend y frontend, crear contacto → aparece con ☆
- [ ] Clicar estrella → pasa a favorito y sube al top
- [ ] Clicar estrella de nuevo → vuelve a ☆ y baja en la lista
- [ ] Recargar página → el orden de favoritos se mantiene (viene del backend)